### PR TITLE
Skip schema validation against built-in verite schemas

### DIFF
--- a/pages/api/verifications/submit.ts
+++ b/pages/api/verifications/submit.ts
@@ -47,7 +47,8 @@ const endpoint = handler(async (req, res) => {
       submission,
       verificationOffer.body.presentation_definition,
       {
-        challenge: verificationOffer.body.challenge
+        challenge: verificationOffer.body.challenge,
+        skipSchemaValidation: true
       }
     )
   } catch (e) {


### PR DESCRIPTION
This will start working once verite is updated, but is fine to merge in the meantime.  