### PR TITLE
manual entry of subject did

### DIFF
--- a/components/form/DidInput.tsx
+++ b/components/form/DidInput.tsx
@@ -1,0 +1,49 @@
+import { ethers } from "ethers"
+import React from "react"
+import type { FC } from "react"
+
+type Props = {
+  value: string
+  setValue: (value: string) => void
+  generateCredential: () => void
+}
+
+declare global {
+  interface Window {
+    ethereum?: ethers.providers.ExternalProvider
+  }
+}
+
+const DidInput: FC<Props> = ({ value, setValue, generateCredential }) => {
+
+
+  return (
+    <>
+      <div className="flex mt-1 rounded-md shadow-sm">
+        <div className="relative flex items-stretch flex-grow focus-within:z-10">
+          <input
+            type="text"
+            name="did"
+            id="did"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            autoComplete="crypto"
+            className="block w-full border-gray-300 rounded-none focus:ring-indigo-500 focus:border-indigo-500 rounded-l-md sm:text-sm"
+            placeholder="did:example:1234"
+          />
+        </div>
+        <button
+          type="button"
+          className="relative inline-flex items-center px-4 py-2 -ml-px space-x-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-r-md bg-gray-50 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+          onClick={() => {
+            generateCredential()
+          }}
+        >
+          <span>Issue Credential</span>
+        </button>
+      </div>
+    </>
+  )
+}
+
+export default DidInput

--- a/components/form/DidInput.tsx
+++ b/components/form/DidInput.tsx
@@ -15,8 +15,6 @@ declare global {
 }
 
 const DidInput: FC<Props> = ({ value, setValue, generateCredential }) => {
-
-
   return (
     <>
       <div className="flex mt-1 rounded-md shadow-sm">

--- a/components/form/VcInput.tsx
+++ b/components/form/VcInput.tsx
@@ -1,0 +1,48 @@
+import { ethers } from "ethers"
+import React from "react"
+import type { FC } from "react"
+
+type Props = {
+  value: string
+  setValue: (value: string) => void
+  generateCredential: () => void
+}
+
+declare global {
+  interface Window {
+    ethereum?: ethers.providers.ExternalProvider
+  }
+}
+
+const VcInput: FC<Props> = ({ value, setValue, generateCredential }) => {
+  return (
+    <>
+      <div className="flex mt-1 rounded-md shadow-sm">
+        <div className="relative flex items-stretch flex-grow focus-within:z-10">
+          <input
+            type="text"
+            name="vc"
+            id="vc"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            autoComplete="crypto"
+            className="block w-full border-gray-300 rounded-none focus:ring-indigo-500 focus:border-indigo-500 rounded-l-md sm:text-sm"
+            placeholder="enter VC jwt"
+          />
+        </div>
+        <button
+          type="button"
+          className="relative inline-flex items-center px-4 py-2 -ml-px space-x-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-r-md bg-gray-50 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+          onClick={() => {
+            generateCredential()
+          }}
+        >
+          <span>Decode Credential</span>
+        </button>
+      </div>
+    </>
+  )
+}
+
+export default VcInput
+

--- a/lib/attestation-fns.ts
+++ b/lib/attestation-fns.ts
@@ -1,6 +1,13 @@
 import { faker } from "@faker-js/faker"
 import { ethers } from "ethers"
-import { ADDRESS_OWNER_ATTESTATION, Attestation, COUNTERPARTY_ACCOUNT_HOLDER_ATTESTATION, KYBPAML_ATTESTATION, KYCAML_ATTESTATION, KYCAML_CREDENTIAL_TYPE_NAME } from "verite"
+import {
+  ADDRESS_OWNER_ATTESTATION,
+  Attestation,
+  COUNTERPARTY_ACCOUNT_HOLDER_ATTESTATION,
+  KYBPAML_ATTESTATION,
+  KYCAML_ATTESTATION,
+  KYCAML_CREDENTIAL_TYPE_NAME
+} from "verite"
 
 import { AttestationKeys, AttestationTypes } from "./constants"
 import { apiDebug } from "./debug"
@@ -46,7 +53,7 @@ export const generateAttestation: GenerateAttestation = async (type, opts) => {
         proof
       }
     }
-  
+
     if (type.id === AttestationKeys.counterparty) {
       return {
         type: COUNTERPARTY_ACCOUNT_HOLDER_ATTESTATION,
@@ -67,7 +74,6 @@ export const generateAttestation: GenerateAttestation = async (type, opts) => {
   throw new Error(`Unknown attestation type: ${type}`)
 }
 
-
 export function getCredentialType(attestationType: string): string {
   if (attestationType === KYCAML_ATTESTATION) {
     return KYCAML_CREDENTIAL_TYPE_NAME
@@ -77,6 +83,6 @@ export function getCredentialType(attestationType: string): string {
     return "AddressOwnerCredential"
   } else if (attestationType === COUNTERPARTY_ACCOUNT_HOLDER_ATTESTATION) {
     return "CounterpartyAccountHolderCredential"
-  } 
+  }
   throw new Error(`Unrecognized attestation type ${attestationType}`)
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,11 @@
-import { ADDRESS_OWNER_ATTESTATION, AttestationDefinition, COUNTERPARTY_ACCOUNT_HOLDER_ATTESTATION, getAttestionDefinition, KYBPAML_ATTESTATION, KYCAML_ATTESTATION } from "verite"
+import {
+  ADDRESS_OWNER_ATTESTATION,
+  AttestationDefinition,
+  COUNTERPARTY_ACCOUNT_HOLDER_ATTESTATION,
+  getAttestionDefinition,
+  KYBPAML_ATTESTATION,
+  KYCAML_ATTESTATION
+} from "verite"
 
 /**
  *
@@ -11,7 +18,7 @@ export type BaseCredentialProperty<T = string> = {
 
 export enum AttestationKeys {
   kycaml = "kycaml",
-  kybpaml =  "kybpaml",
+  kybpaml = "kybpaml",
   address = "addresss",
   counterparty = "counterparty"
 }
@@ -19,10 +26,8 @@ export enum AttestationKeys {
 /**
  *
  */
-export type AttestationTypes = BaseCredentialProperty<
-AttestationKeys
-> & {
-  type: string,
+export type AttestationTypes = BaseCredentialProperty<AttestationKeys> & {
+  type: string
   definition: AttestationDefinition
 }
 
@@ -86,7 +91,6 @@ export const ATTESTATION_TYPES: AttestationTypes[] = [
     name: "Address Ownership",
     type: ADDRESS_OWNER_ATTESTATION,
     definition: getAttestionDefinition(ADDRESS_OWNER_ATTESTATION)
-
   },
   {
     id: AttestationKeys.counterparty,

--- a/lib/manifest-fns.ts
+++ b/lib/manifest-fns.ts
@@ -1,12 +1,17 @@
-import { CredentialManifest, CredentialManifestBuilder, PresentationDefinition, proofOfControlPresentationDefinition } from "verite"
+import {
+  CredentialManifest,
+  CredentialManifestBuilder,
+  PresentationDefinition,
+  proofOfControlPresentationDefinition
+} from "verite"
 
 import { apiDebug } from "./debug"
 
 import { CredentialIssuer, AttestationTypes } from "lib/constants"
 import { getOutputDescriptors } from "lib/manifest/output-descriptors"
 
-
-const PRESENTATION_DEFINITION: PresentationDefinition = proofOfControlPresentationDefinition()
+const PRESENTATION_DEFINITION: PresentationDefinition =
+  proofOfControlPresentationDefinition()
 
 export type GenerateManifest = (
   type: AttestationTypes,
@@ -17,13 +22,16 @@ export type GenerateManifest = (
  *
  */
 export const generateManifest: GenerateManifest = (type, issuer) => {
-  apiDebug(`generateManifest => getAttestationInformation(${JSON.stringify(type)})`)
+  apiDebug(
+    `generateManifest => getAttestationInformation(${JSON.stringify(type)})`
+  )
   const outputDescriptors = getOutputDescriptors(issuer.name, type)
-  return new CredentialManifestBuilder(type.type).issuer( {
-    id: issuer.did.key,
-    name: issuer.name
-  })
-  .output_descriptors(outputDescriptors)
-  .presentation_definition(PRESENTATION_DEFINITION)
-  .build()
+  return new CredentialManifestBuilder(type.type)
+    .issuer({
+      id: issuer.did.key,
+      name: issuer.name
+    })
+    .output_descriptors(outputDescriptors)
+    .presentation_definition(PRESENTATION_DEFINITION)
+    .build()
 }

--- a/lib/manifest/output-descriptors/address.ts
+++ b/lib/manifest/output-descriptors/address.ts
@@ -1,15 +1,27 @@
-import { LabeledDisplayMappingBuilder, OutputDescriptor, STRING_SCHEMA } from "verite"
+import {
+  LabeledDisplayMappingBuilder,
+  OutputDescriptor,
+  STRING_SCHEMA
+} from "verite"
 
 import { AttestationTypes } from "lib/constants"
 
-export function getOutputDescriptors(issuerName: string, type: AttestationTypes): OutputDescriptor[] {
-
+export function getOutputDescriptors(
+  issuerName: string,
+  type: AttestationTypes
+): OutputDescriptor[] {
   const properties = [
-    new LabeledDisplayMappingBuilder("Chain", STRING_SCHEMA).path([`$.${type.type}.chain`]).build(),
-    new LabeledDisplayMappingBuilder("Address", STRING_SCHEMA).path([`$.${type.type}.address`]).build(),
-    new LabeledDisplayMappingBuilder("Proof", STRING_SCHEMA).path([`$.${type.type}.proof`]).build(),
+    new LabeledDisplayMappingBuilder("Chain", STRING_SCHEMA)
+      .path([`$.${type.type}.chain`])
+      .build(),
+    new LabeledDisplayMappingBuilder("Address", STRING_SCHEMA)
+      .path([`$.${type.type}.address`])
+      .build(),
+    new LabeledDisplayMappingBuilder("Proof", STRING_SCHEMA)
+      .path([`$.${type.type}.proof`])
+      .build()
   ]
-   const outputs = [
+  const outputs = [
     {
       id: `${type.type}`,
       schema: type.definition.schema,
@@ -31,5 +43,4 @@ export function getOutputDescriptors(issuerName: string, type: AttestationTypes)
     }
   ]
   return outputs
-
 }

--- a/lib/manifest/output-descriptors/counterparty.ts
+++ b/lib/manifest/output-descriptors/counterparty.ts
@@ -1,13 +1,22 @@
-import { LabeledDisplayMappingBuilder, OutputDescriptor, STRING_SCHEMA } from "verite"
+import {
+  LabeledDisplayMappingBuilder,
+  OutputDescriptor,
+  STRING_SCHEMA
+} from "verite"
 
 import { AttestationTypes } from "lib/constants"
 
-
-export function getOutputDescriptors(issuerName: string, type: AttestationTypes): OutputDescriptor[] {
-
+export function getOutputDescriptors(
+  issuerName: string,
+  type: AttestationTypes
+): OutputDescriptor[] {
   const properties = [
-    new LabeledDisplayMappingBuilder("Legal Name", STRING_SCHEMA).path([`$.${type.type}.legalName`]).build(),
-    new LabeledDisplayMappingBuilder("Account Holder", STRING_SCHEMA).path([`$.${type.type}.accountHolder`]).build(),
+    new LabeledDisplayMappingBuilder("Legal Name", STRING_SCHEMA)
+      .path([`$.${type.type}.legalName`])
+      .build(),
+    new LabeledDisplayMappingBuilder("Account Holder", STRING_SCHEMA)
+      .path([`$.${type.type}.accountHolder`])
+      .build()
   ]
 
   const outputs = [

--- a/lib/manifest/output-descriptors/index.ts
+++ b/lib/manifest/output-descriptors/index.ts
@@ -1,4 +1,3 @@
-
 import { OutputDescriptor } from "verite"
 
 import { getOutputDescriptors as addressOutputs } from "./address"
@@ -8,7 +7,10 @@ import { getOutputDescriptors as kycamlOutputs } from "./kycaml"
 
 import { AttestationKeys, AttestationTypes } from "lib/constants"
 
-export function getOutputDescriptors(issuerName: string, type: AttestationTypes) : OutputDescriptor[] {
+export function getOutputDescriptors(
+  issuerName: string,
+  type: AttestationTypes
+): OutputDescriptor[] {
   if (type.id === AttestationKeys.kycaml) {
     return kycamlOutputs(issuerName, type)
   } else if (type.id === AttestationKeys.kybpaml) {

--- a/lib/manifest/output-descriptors/kybaml.ts
+++ b/lib/manifest/output-descriptors/kybaml.ts
@@ -2,8 +2,10 @@ import { DataDisplayBuilder, OutputDescriptor } from "verite"
 
 import { AttestationTypes } from "lib/constants"
 
-export function getOutputDescriptors(issuerName: string, type: AttestationTypes): OutputDescriptor[] {
-
+export function getOutputDescriptors(
+  issuerName: string,
+  type: AttestationTypes
+): OutputDescriptor[] {
   const display = new DataDisplayBuilder({
     title: {
       text: `${issuerName} KYBP/AML Attestation`
@@ -14,16 +16,19 @@ export function getOutputDescriptors(issuerName: string, type: AttestationTypes)
     },
     description: {
       text: "The KYBP authority processes Know Your Business Partner and Anti-Money Laundering analysis, potentially employing a number of internal and external vendor providers."
-    },
-  }).addStringProperty("Process", b => b.path([`$.${type.type}.process`]))
-  .addDateTimeProperty("Approved At", b => b.path([`$.${type.type}.approvalDate`]))
+    }
+  })
+    .addStringProperty("Process", (b) => b.path([`$.${type.type}.process`]))
+    .addDateTimeProperty("Approved At", (b) =>
+      b.path([`$.${type.type}.approvalDate`])
+    )
 
-  return  [
+  return [
     {
       id: `${type.id}`,
       schema: type.definition.schema,
       name: `Proof of Know Your Business Partner and Anti-Money Laundering from ${issuerName}`,
-      description:  `Attestation that ${issuerName} has completed KYBP/AML verification for this subject`,
+      description: `Attestation that ${issuerName} has completed KYBP/AML verification for this subject`,
       display: display.build()
     }
   ]

--- a/lib/manifest/output-descriptors/kycaml.ts
+++ b/lib/manifest/output-descriptors/kycaml.ts
@@ -2,8 +2,10 @@ import { DataDisplayBuilder, OutputDescriptor } from "verite"
 
 import { AttestationTypes } from "lib/constants"
 
-export function getOutputDescriptors(issuerName: string, type: AttestationTypes): OutputDescriptor[] {
-
+export function getOutputDescriptors(
+  issuerName: string,
+  type: AttestationTypes
+): OutputDescriptor[] {
   const display = new DataDisplayBuilder({
     title: {
       text: `${issuerName} KYC Attestation`
@@ -14,11 +16,14 @@ export function getOutputDescriptors(issuerName: string, type: AttestationTypes)
     },
     description: {
       text: "The KYC authority processes Know Your Customer and Anti-Money Laundering analysis, potentially employing a number of internal and external vendor providers."
-    },
-  }).addStringProperty("Process", b => b.path([`$.${type.type}.process`]))
-  .addDateTimeProperty("Approved At", b => b.path([`$.${type.type}.approvalDate`]))
+    }
+  })
+    .addStringProperty("Process", (b) => b.path([`$.${type.type}.process`]))
+    .addDateTimeProperty("Approved At", (b) =>
+      b.path([`$.${type.type}.approvalDate`])
+    )
 
-  return  [
+  return [
     {
       id: `${type.id}`,
       schema: type.definition.schema,

--- a/lib/verification-fns.ts
+++ b/lib/verification-fns.ts
@@ -25,7 +25,6 @@ export const generateVerificationOffer = ({
   subjectAddress,
   chainId
 }: GenerateVerificationOfferParams) => {
-
   const pd = getPresentationDefinition(attestationType, trustedIssuers)
 
   const params = new URLSearchParams({

--- a/lib/verification/presentation-definitions/index.ts
+++ b/lib/verification/presentation-definitions/index.ts
@@ -8,12 +8,10 @@ import {
 
 import { AttestationKeys, AttestationTypes } from "lib/constants"
 
-
 export function getPresentationDefinition(
   type: AttestationTypes,
   trustedAuthorities: string[] = []
 ): PresentationDefinition {
-
   const attestationInfo = type.definition
   const prefix = `${type.type}.`
 
@@ -36,30 +34,39 @@ export function getPresentationDefinition(
       trustedAuthorities
     )
   } else if (type.id === AttestationKeys.counterparty) {
-    return new PresentationDefinitionBuilder({id: "CounterpartyAccountHolderPresentationDefinition"})
-    .addInputDescriptor("CounterpartyAccountHolderCredential", (c) => {
-      c.name("Counterparty PII Compliance")
-      .purpose("Please provide a valid credential from a trusted issuer")
-      .withConstraints((b) => {
-        b.addField(stringValueConstraint("legalName", prefix))
-        .addField(stringValueConstraint("accountNumber", prefix))
+    return new PresentationDefinitionBuilder({
+      id: "CounterpartyAccountHolderPresentationDefinition"
+    })
+      .addInputDescriptor("CounterpartyAccountHolderCredential", (c) => {
+        c.name("Counterparty PII Compliance")
+          .purpose("Please provide a valid credential from a trusted issuer")
+          .withConstraints((b) => {
+            b.addField(stringValueConstraint("legalName", prefix)).addField(
+              stringValueConstraint("accountNumber", prefix)
+            )
+          })
+          .withConstraints(
+            withDefaults(attestationInfo.schema, trustedAuthorities)
+          )
       })
-      .withConstraints(withDefaults(attestationInfo.schema, trustedAuthorities))
-    }).build()
-
+      .build()
   } else if (type.id === AttestationKeys.address) {
-    return new PresentationDefinitionBuilder({id: "AddressPresentationDefinition"})
-    .addInputDescriptor("AddressOwnerCredential", (c) => {
-      c.name("Proof of Address Ownership")
-      .purpose("Please provide a valid credential from a truested issuer")
-      .withConstraints((b) => {
-        b.addField(stringValueConstraint("chain", prefix))
-        .addField(stringValueConstraint("address", prefix))
-        .addField(stringValueConstraint("proof", prefix))
+    return new PresentationDefinitionBuilder({
+      id: "AddressPresentationDefinition"
+    })
+      .addInputDescriptor("AddressOwnerCredential", (c) => {
+        c.name("Proof of Address Ownership")
+          .purpose("Please provide a valid credential from a truested issuer")
+          .withConstraints((b) => {
+            b.addField(stringValueConstraint("chain", prefix))
+              .addField(stringValueConstraint("address", prefix))
+              .addField(stringValueConstraint("proof", prefix))
+          })
+          .withConstraints(
+            withDefaults(attestationInfo.schema, trustedAuthorities)
+          )
       })
-      .withConstraints(withDefaults(attestationInfo.schema, trustedAuthorities))
-    }).build()
+      .build()
   }
   throw new Error(`Unrecognized presentation defniition id ${type.id}`)
-
 }

--- a/pages/api/credentials/offer.ts
+++ b/pages/api/credentials/offer.ts
@@ -25,7 +25,9 @@ const endpoint = handler((req, res) => {
   const issuer = findCredentialIssuer(req.query.issuer as string)
   const status = findCredentialStatus(req.query.status as string)
   const chainId =
-    type.id === AttestationKeys.address ? findChainId(req.query.chain as string) : undefined
+    type.id === AttestationKeys.address
+      ? findChainId(req.query.chain as string)
+      : undefined
 
   const id = [type.id, issuer.id, status.id, chainId?.type]
     .filter(Boolean)

--- a/pages/api/credentials/submit.ts
+++ b/pages/api/credentials/submit.ts
@@ -36,7 +36,9 @@ const endpoint = handler(async (req, res) => {
   const issuerInfo = findCredentialIssuer(req.query.issuer as string)
   const status = findCredentialStatus(req.query.status as string)
   const chainId =
-    type.id === AttestationKeys.address ? findChainId(req.query.chain as string) : undefined
+    type.id === AttestationKeys.address
+      ? findChainId(req.query.chain as string)
+      : undefined
 
   /**
    * Get signer (issuer)
@@ -51,7 +53,7 @@ const endpoint = handler(async (req, res) => {
 
   apiDebug(`Issuer generating manifest for type.id=${type.id}`)
   const manifest = generateManifest(type, issuerInfo)
-  
+
   /**
    * Using Presentation Exchange, the client will submit a credential
    * application. Since we are using JWTs to format the data, we first must

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,19 @@
+import { InformationCircleIcon } from "@heroicons/react/solid"
+import Tippy from "@tippyjs/react"
 import type { NextPage } from "next"
 import { useEffect, useMemo, useState } from "react"
-import Tippy from "@tippyjs/react"
-import { InformationCircleIcon } from "@heroicons/react/solid"
-import { buildAndSignVerifiableCredential, buildIssuer, challengeTokenUrlWrapper, getCredentialSchemaAsVCObject } from "verite"
+import {
+  buildAndSignVerifiableCredential,
+  buildIssuer,
+  challengeTokenUrlWrapper,
+  getCredentialSchemaAsVCObject
+} from "verite"
 
 import FAQ, { FAQType } from "components/FAQ"
 import QRCode from "components/credentials/QRCode"
+import DidInput from "components/form/DidInput"
 import SelectBox from "components/form/SelectBox"
+import { generateAttestation, getCredentialType } from "lib/attestation-fns"
 import {
   ChainId,
   CHAIN_IDS,
@@ -18,11 +25,9 @@ import {
   ATTESTATION_TYPES,
   AttestationKeys
 } from "lib/constants"
-import { fullURL } from "lib/url-fns"
-import DidInput from "components/form/DidInput"
 import { expirationDateForStatus } from "lib/credential-fns"
-import { generateAttestation, getCredentialType } from "lib/attestation-fns"
 import { generateRevocationListStatus } from "lib/revocation-fns"
+import { fullURL } from "lib/url-fns"
 
 const faqs: FAQType[] = [
   {
@@ -113,7 +118,7 @@ const Page: NextPage = () => {
   const [did, setDid] = useState("")
 
   useEffect(() => {
-    setUseDid(did !== '')
+    setUseDid(did !== "")
     setVc("")
   }, [did])
 
@@ -133,7 +138,6 @@ const Page: NextPage = () => {
       chain: chainId?.type
     })
     const credentialType = getCredentialType(attestation.type)
-
 
     // Build a revocation list and index.
     const revocationListStatus = await generateRevocationListStatus(
@@ -156,7 +160,6 @@ const Page: NextPage = () => {
 
     console.log(JSON.stringify(vc))
   }
-
 
   const qrCodeContents = useMemo(() => {
     const params = new URLSearchParams({
@@ -221,8 +224,9 @@ const Page: NextPage = () => {
                 <div>
                   <SelectBox
                     label="Issuer"
-                    labelTooltip={`Select the issuer of this credential. By default '${CREDENTIAL_ISSUERS.find((c) => c.isTrusted)?.name
-                      }' is the only trusted issuer, but this can be customized on the verifier screen`}
+                    labelTooltip={`Select the issuer of this credential. By default '${
+                      CREDENTIAL_ISSUERS.find((c) => c.isTrusted)?.name
+                    }' is the only trusted issuer, but this can be customized on the verifier screen`}
                     items={CREDENTIAL_ISSUERS}
                     selected={customIssuer}
                     setSelected={setCustomIssuer}
@@ -261,7 +265,6 @@ const Page: NextPage = () => {
                     generateCredential={generateCredential}
                   />
                 </div>
-
               </form>
             </div>
             <div className="text-right sm:w-1/2">
@@ -281,9 +284,7 @@ const Page: NextPage = () => {
                   />
                 </>
               )}
-
             </div>
-
           </div>
         </div>
       </div>


### PR DESCRIPTION
Before this change, the credential faucet assumed the presence of a credential wallet that understands Credential Manifest and Presentation Exchange. This adds the ability to get samples of Verite JC JWTs, without requiring a wallet. 

Note that the display is clumsy and the issue/verify screens are not quite symmetric; i.e. with the manual VC JWT input, the UI displays the decoded VC and not the fully verified result (skipping ownership and status checks), but those can be added later. Ideally we will clean this up at the verite library layer -- this change pointed out the verification apis could be cleaner